### PR TITLE
revise readme to indicate plural table name

### DIFF
--- a/README.md
+++ b/README.md
@@ -94,7 +94,7 @@ Assuming you have a Brand model:
     class Brand < ActiveRecord::Base
     end
 
-    create_table :brand do |t|
+    create_table :brands do |t|
       t.column :name, :string
     end
 


### PR DESCRIPTION
Active Record table names should be plural so I made this minor change just for clarity.
